### PR TITLE
Add option to ignore mounted horse

### DIFF
--- a/src/main/java/net/pancham138/horseinfo/HorseInfo.java
+++ b/src/main/java/net/pancham138/horseinfo/HorseInfo.java
@@ -1,9 +1,9 @@
 package net.pancham138.horseinfo;
 
 import java.text.DecimalFormat;
-import java.util.List;
 
 import mcp.mobius.waila.api.*;
+import net.minecraft.entity.player.PlayerEntity;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 
@@ -24,6 +24,7 @@ public class HorseInfo implements ModInitializer, IWailaPlugin, IEntityComponent
     public static final String MOD_NAME = "Hwyla Addon Horse Info";
     
     private static final Identifier ENABLED = new Identifier(MOD_ID, "enabled");
+    private static final Identifier IGNORE_MOUNT = new Identifier(MOD_ID, "ignoremount");
     private static final DecimalFormat FORMAT = new DecimalFormat("#.##");
     
     @Override
@@ -36,10 +37,23 @@ public class HorseInfo implements ModInitializer, IWailaPlugin, IEntityComponent
         LOGGER.log(Level.INFO, "Registering ", MOD_NAME);
 
         registrar.addConfig(ENABLED, true);
-        
+        registrar.addConfig(IGNORE_MOUNT, false);
+
         registrar.addComponent(this, TooltipPosition.BODY, HorseBaseEntity.class);
+        registrar.addOverride(this, HorseBaseEntity.class);
     }
-    
+
+    @Override
+    public Entity getOverride(IEntityAccessor accessor, IPluginConfig config) {
+        if (config.getBoolean(IGNORE_MOUNT) && accessor.getEntity() instanceof HorseBaseEntity horse) {
+            final PlayerEntity player = accessor.getPlayer();
+            if (player != null && player.hasVehicle() && player.getVehicle() == horse) {
+                return IEntityComponentProvider.EMPTY_ENTITY;
+            }
+        }
+        return null;
+    }
+
     @Override
     public void appendBody(ITooltip tooltip, IEntityAccessor accessor, IPluginConfig config) {
         if (config.getBoolean(ENABLED)) {
@@ -47,7 +61,7 @@ public class HorseInfo implements ModInitializer, IWailaPlugin, IEntityComponent
             
             if (entity instanceof HorseBaseEntity) {
                 final HorseBaseEntity horse = (HorseBaseEntity)entity;
-                
+
                 final double jumpStrength = horse.getJumpStrength();
                 final double jumpHeight = -0.1817584952f * Math.pow(jumpStrength, 3) + 3.689713992f * Math.pow(jumpStrength, 2) + 2.128599134f * jumpStrength - 0.343930367f;
                 

--- a/src/main/resources/assets/horseinfo/lang/en_us.json
+++ b/src/main/resources/assets/horseinfo/lang/en_us.json
@@ -3,5 +3,6 @@
     "tooltip.horseinfo.speed": "Speed: %s m/s",
     
     "config.waila.plugin_horseinfo": "Horse Info",
-    "config.waila.plugin_horseinfo.enabled": "Enable"
+    "config.waila.plugin_horseinfo.enabled": "Enable",
+    "config.waila.plugin_horseinfo.ignoremount": "Ignore Mounted Horse"
 }


### PR DESCRIPTION
This PR adds a config option to hide the HWYLA tooltip for mounted horses.

The option is set to false by default.